### PR TITLE
Added a note reminding the user to include the ion-fab-button module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Android [floating action button](http://www.google.com/design/spec/components/bu
 
 ## Usage
 
-Include `ion-fabButton.css` and `ion-fabButton.js` after the rest of your Ionic and Angular includes. Then use the following AngularJS directives:
+Include `ion-fabButton.css` and `ion-fabButton.js` after the rest of your Ionic and Angular includes and add the `ion-fab-button` module to your configuration. Then use the following AngularJS directives:
 
 ```html
 <fab-button target-id="scrollFabButtonTarget">


### PR DESCRIPTION
Just a small readme update reminding the user to add the module to their Angular app. I totally forgot and it took me a few minutes looking at the Codepen to realize it.
